### PR TITLE
Replaced variable removed

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -24,7 +24,7 @@ containerized=True
 os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 openshift_disable_check=disk_availability,docker_storage,memory_availability,docker_image_availability
 
-openshift_node_kubelet_args={'pods-per-core': ['10']}
+#openshift_node_kubelet_args={'pods-per-core': ['10']}
 
 deployment_type=origin
 openshift_deployment_type=origin


### PR DESCRIPTION
last_checked_var: openshift_master_identity_providers;Found removed variables: openshift_node_kubelet_args is replaced by openshift_node_groups[<item>].edits;

Since the install fails ont he above and the inventory.ini file is downloaded every time fromt eh configured repo I had to fork and commit this.
without the node_groups, it will all back to the default.